### PR TITLE
Server: Fixes #10118 - TypeError when running "process orphaned items" on Joplin server

### DIFF
--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -123,7 +123,7 @@ export default class UserItemModel extends BaseModel<UserItem> {
 
 		await this.withTransaction(async () => {
 			for (const item of items) {
-				if (!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
+				if (!item ||!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
 
 				await super.save({
 					user_id: userId,


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->
This pull request addresses issue #, which involves resolving a TypeError encountered when running the "process orphaned items" functionality via the Web UI on Linux systems. The current behavior triggers a TypeError stating, "Cannot use 'in' operator to search for 'name' in undefined."

The expected behavior is that this operation should execute without errors.

To resolve this issue, the code has been adjusted to handle the undefined value appropriately, preventing the TypeError from occurring. 